### PR TITLE
Log settings should be strings, not atoms

### DIFF
--- a/source/elixir/configuration/options.html.md.erb
+++ b/source/elixir/configuration/options.html.md.erb
@@ -162,10 +162,10 @@ List of namespaces that will be ignored. Any error raised or slow request that o
 
 ## `APPSIGNAL_LOG` / `:log`
 
-- Value: Atom. Default: `:file`
+- Value: Atom. Default: `"file"`
 
 Select which logger to the AppSignal agent should use. Accepted values are
-`:file` and `:stdout`. See also the `log_path` configuration.
+`"file"` and `"stdout"`. See also the `log_path` configuration.
 
 - `file` (default)
   - Write all AppSignal logs to the file system.


### PR DESCRIPTION
[Referencing "file"](https://github.com/appsignal/appsignal-elixir/blob/d79270773560a1763ca9a11493bc3b66c409f2b9/lib/appsignal/config.ex#L22)
[Referencing "stdout"](https://github.com/appsignal/appsignal-elixir/blob/d79270773560a1763ca9a11493bc3b66c409f2b9/lib/appsignal/config.ex#L169)